### PR TITLE
Passes the PyPI password as a string to twine to support special characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Publish package to PyPI
         run: |
-          twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
+          twine upload -u ${{ secrets.PYPI_USERNAME }} -p '${{ secrets.PYPI_PASSWORD }}' dist/*
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Publish package to PyPI
         run: |
-          twine upload -u ${{ secrets.PYPI_USERNAME }} -p '${{ secrets.PYPI_PASSWORD }}' dist/*
+          twine upload -u '${{ secrets.PYPI_USERNAME }}' -p '${{ secrets.PYPI_PASSWORD }}' dist/*
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Passes the PyPI password as a string into twine in order to support special characters (e.g., spaces) in a PyPI password. (This was previously failing and causing a bug.)

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/python-package-template/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/python-package-template/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
