### PR TITLE
chore: move configurations to `pyproject.toml`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,0 @@
-[mypy]
-ignore_missing_imports = true
-no_site_packages = true
-
-[mypy-tests.*]
-strict_optional = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,12 @@ no_site_packages = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 strict_optional = false
+
+[tool.pytest.ini_options]
+testpaths = "tests/"
+python_classes = [
+  "Test*",
+  "*Test"
+]
+log_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+log_level = "DEBUG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,11 @@ reportPrivateImportUsage = false
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+ignore_missing_imports = true
+no_site_packages = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+strict_optional = false

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-testpaths = tests/
-python_classes = Test* *Test
-log_format = %(asctime)s - %(levelname)s - %(name)s - %(message)s
-log_level = DEBUG
-markers =
-filterwarnings =


### PR DESCRIPTION
This PR aims to minimize the number of configuration files for the project. Instead of a separate `pytest.ini` and `mypy.ini`, we now would have all the configurations within the `pyproject.toml` file leading to a overall minimal code structure.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
