### PR TITLE
fix personalize.py on Windows

### DIFF
--- a/scripts/personalize.py
+++ b/scripts/personalize.py
@@ -132,7 +132,7 @@ def main(
         if not dry_run:
             if path.name == "personalize.py" and sys.platform.startswith("win"):
                 # We can't unlink/remove an open file on Windows.
-                print(f"You can remove the 'scripts/personalize.py' file now")
+                print("You can remove the 'scripts/personalize.py' file now")
             else:
                 path.unlink()
 


### PR DESCRIPTION
Fixes #80, `personalize.py` will now work on Windows by not removing the file itself. Instead we'll just print a message for the user to delete the file manually.
